### PR TITLE
Switch unix socket to /run

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,7 @@ php_uploads: "On"
 php_maxuploadsize: "256M"
 php_maxuploads: "20"
 
-php_socket: "/var/run/php-fpm/php-fpm.sock"
+php_socket: "/run/php-fpm/php-fpm.sock"
 
 php_allowed_clients: ""
 php_niceness: ""

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -10,7 +10,7 @@
       systemd:
         name: nginx
         state: started
-        enabled: yes
+        enabled: true
     - name: "Include geekoops-php-fpm"
       include_role:
         name: "geekoops-php-fpm"
@@ -37,7 +37,7 @@
                       try_files $uri $uri/ =404;
                   }
                   location ~ \.php$ {
-                      fastcgi_pass   unix:/var/run/php-fpm/php-fpm.sock;
+                      fastcgi_pass   unix:/run/php-fpm/php-fpm.sock;
                       fastcgi_index  index.php;
                       fastcgi_param  SCRIPT_FILENAME $request_filename;
                       include        fastcgi_params;


### PR DESCRIPTION
Switch the unix socket from /var/run to /run to comply with the current
AppArmor profile for php-fpm.