### PR TITLE
make the php temp directory configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Due to the very different php configuration on Debian/Ubuntu I'm not planning to
 | `php_chroot` | If set, chroot to this directory as start. If set, you might also need to set `php_chdir = /` |  |
 | `php_limit_extensions` | Limit the extension that php-fpm will be parsing | `.php .php3 .php4 .php5 .php7` |
 | `php_env_PATH` | Set the `PATH` variable for php-fpm | `/usr/local/bin:/usr/bin:/bin` |
+| `php_env_tmp` | Set the tmp directory for php-fpm | `/tmp` |
 | `php_open_basedir` | If set, this limits all file operations to the defined directory and below |  |
 | `php_disable_functions` | Allows you to disable certain function |  |
 | `php_disable_classes` | Allows you to disable certain function |  |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ php_chroot: ""
 php_limit_extensions: "{{ '.php .php3 .php4 .php5 .php7 .php8' if php_ver == 'php8' else  '.php .php3 .php4 .php5 .php7' }}"
 
 php_env_PATH: "/usr/local/bin:/usr/bin:/bin"
-
+php_env_tmp: "/tmp"
 php_open_basedir: ""
 php_disable_functions: ""
 php_disable_classes: ""

--- a/templates/www.conf.j2
+++ b/templates/www.conf.j2
@@ -90,9 +90,9 @@ security.limit_extensions = {{ php_limit_extensions }}
 ; the current environment.
 ; Default Value: clean env
 env[PATH] = {{ php_env_PATH }}
-env[TMP] = /tmp
-env[TMPDIR] = /tmp
-env[TEMP] = /tmp
+env[TMP] = {{ php_env_tmp }}
+env[TMPDIR] = {{ php_env_tmp }}
+env[TEMP] = {{ php_env_tmp }}
 
 ; Additional php.ini defines, specific to this pool of workers. These settings
 ; overwrite the values previously defined in the php.ini. The directives are the


### PR DESCRIPTION
This makes the tmp directory configurable. Useful with nextcloud which wants to write to /tmp ...